### PR TITLE
Update to support 1.21.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.2
-loader_version=0.15.11
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.4
+loader_version=0.16.9
 
 # Mod Properties
 mod_version=1.1.0
@@ -14,6 +14,6 @@ maven_group=com.stencode.breakable
 archives_base_name=breakable
 
 # Dependencies
-fabric_version=0.100.1+1.21
-modmenu_version=11.0.0-beta.2
-cloth_version=15.0.127
+fabric_version=0.113.0+1.21.4
+modmenu_version=13.0.0-beta.1
+cloth_version=17.0.144

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/com/stencode/breakable/BreakableClient.java
+++ b/src/client/java/com/stencode/breakable/BreakableClient.java
@@ -22,7 +22,6 @@ import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.TypedActionResult;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.lwjgl.glfw.GLFW;
@@ -50,14 +49,14 @@ public class BreakableClient implements ClientModInitializer {
             // When the player is right-clicking an item without looking at a block or entity
             ItemStack itemStack = player.getStackInHand(hand);
             if (!ModConfig.INSTANCE.enabled || !itemStack.isDamageable() || overwriteKey.isPressed())
-                return TypedActionResult.pass(itemStack);
+                return ActionResult.PASS;
 
             Item item = itemStack.getItem();
             if (item instanceof FishingRodItem) {
                 // The maximum amount of damage on a fishing rod that can be done in 1 action is yanking a mob which costs 5 durability.
                 if (itemStack.getMaxDamage() - itemStack.getDamage() <= 5) {
                     notify(player);
-                    return TypedActionResult.fail(itemStack);
+                    return ActionResult.FAIL;
                 }
             } else if (item instanceof CrossbowItem) {
                 Item projectile = player.getProjectileType(itemStack).getItem();
@@ -67,27 +66,27 @@ public class BreakableClient implements ClientModInitializer {
                 } else {
                     damage = 1;
                 }
-                RegistryEntry<Enchantment> entry = world.getRegistryManager().getWrapperOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.MULTISHOT);
+                RegistryEntry<Enchantment> entry = world.getRegistryManager().getOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.MULTISHOT);
                 int projectiles = EnchantmentHelper.getLevel(entry, itemStack) == 0 ? 1 : 3;
                 damage *= projectiles;
 
                 if (itemStack.getMaxDamage() - itemStack.getDamage() <= damage) {
                     notify(player);
-                    return TypedActionResult.fail(itemStack);
+                    return ActionResult.FAIL;
                 }
             } else if (item instanceof BowItem || item instanceof TridentItem) {
                 if (itemStack.getMaxDamage() - itemStack.getDamage() <= 1) {
                     notify(player);
-                    return TypedActionResult.fail(itemStack);
+                    return ActionResult.FAIL;
                 }
             } else if (item instanceof ShieldItem) {
                 if (itemStack.getMaxDamage() - itemStack.getDamage() <= ModConfig.INSTANCE.shieldDamageThreshold) {
                     notify(player);
-                    return TypedActionResult.fail(itemStack);
+                    return ActionResult.FAIL;
                 }
             }
 
-            return TypedActionResult.pass(itemStack);
+            return ActionResult.PASS;
         });
 
         AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {

--- a/src/client/resources/fabric.mod.json
+++ b/src/client/resources/fabric.mod.json
@@ -29,8 +29,8 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.15.11",
-		"minecraft": "~1.21",
+		"fabricloader": ">=0.16.9",
+		"minecraft": "~1.21.4",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
Updates dependencies to latest available 1.21.4 compatible version, and upgrades Gradle to 8.11 as required by Loom 1.9.

Also accounts for breaking changes made in 1.21.2 as outlined in the [Fabric for Minecraft 1.21.2](https://fabricmc.net/2024/10/14/1212.html) blog post.